### PR TITLE
Three fixes in the template

### DIFF
--- a/main.tmpl
+++ b/main.tmpl
@@ -623,7 +623,7 @@ def print_params( params ):
                                 $param.description
                               </li>
                             #end for
-                          <ul>
+                          </ul>
                         #end if
 
                         #if $method.chainable
@@ -769,7 +769,7 @@ def print_params( params ):
                                 $param.description
                               </li>
                             #end for
-                          <ul>
+                          </ul>
                         #end if
 
                         #if $event.bubbles

--- a/main.tmpl
+++ b/main.tmpl
@@ -34,7 +34,12 @@ def print_params( params ):
   <meta name="viewport" content="width=device-width; initial-scale=1.0">
 
   <title>
-    API: $modulename
+    API:
+    #if $modulename
+      $modulename
+    #else
+      $projectname
+    #end if#
     #if $classname#
       &rarr; $classname class
     #end if#

--- a/main.tmpl
+++ b/main.tmpl
@@ -609,7 +609,7 @@ def print_params( params ):
                           </div>
                         #end if
 
-                        $method.description
+                        <p>$method.description</p>
 
                         #if $method.params
                           <p>Parameters:</p>


### PR DESCRIPTION
Added `<p>` tag for method description, fixed two incorrect `<ul>` closing tags and the template now uses the project name instead of module name at root.
